### PR TITLE
Add non-functional requirements tests

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4041,6 +4041,11 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
+    "log": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/log/-/log-1.4.0.tgz",
+      "integrity": "sha1-S6HYkP3iSbAx3KA7w36q8yVlbxw="
+    },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
@@ -4850,6 +4855,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
+    "performance": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/performance/-/performance-1.4.0.tgz",
+      "integrity": "sha512-0e98N5lSIe7Nuts/4MW/6D1q+c5qT74yEv/t/TneeFeGl5wgoaiDzQPSvNL/Qe5vFFRvQsqHCrv83Y4GB33Xnw==",
+      "requires": {
+        "stdio": "*",
+        "testing": "*"
+      }
     },
     "performance-now": {
       "version": "2.1.0",
@@ -5809,6 +5823,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "stdio": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/stdio/-/stdio-2.1.1.tgz",
+      "integrity": "sha512-ZHO7SD10nZnc2pMN85MPPTCKutXPKH+7Z50B7zt/JRNAHXLbI3BidMc9HFD/j2VupZ8lQdSVJB0ebZSVXC6uXw=="
+    },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
@@ -6086,6 +6105,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
+      }
+    },
+    "testing": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/testing/-/testing-2.0.1.tgz",
+      "integrity": "sha512-2zQ08tZ0fm7ziEsST6DIzIear/sz7AntmxlGsBm+1OPY1ymVzc9HGcLqLuJhwON1npQW/M2eRsukPliSSma+1Q==",
+      "requires": {
+        "log": "1.4.0"
       }
     },
     "throat": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "jest": "26.6.1",
     "mongodb": "^3.6.2",
     "mongoose": "^5.10.14",
+    "performance": "^1.4.0",
     "supertest": "^6.0.1",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.5",

--- a/backend/test/non-functional-requirements/nfr.test.js
+++ b/backend/test/non-functional-requirements/nfr.test.js
@@ -1,27 +1,23 @@
 require("dotenv").config();
 const axios = require("axios");
-const performance = require('perf_hooks').performance;
+const performance = require("perf_hooks").performance;
 
-let serverUrl = "http://52.52.51.125:8081/"
+let serverUrl = "http://52.52.51.125:8081/";
 
 async function testMassJoin(tokens, pin) {
-    var session_url = serverUrl + "session/" + pin;
+    var sessionUrl = serverUrl + "session/" + pin;
     for (var i = 0; i < tokens.length; i++) {
-        await axios.post(session_url, Object(), { headers: { 'facebooktoken': tokens[i] } });
+        await axios.post(sessionUrl, Object(), { headers: { "facebooktoken": tokens[parseInt(i)] } });
     }
-    var max_users = await axios.get(session_url, { headers: { 'facebooktoken': tokens[0] } })
-        .then((sessionResponse) => {
-            return sessionResponse.data.participants.length;
-        });
-    return max_users;
+    var maxUsers = await axios.get(sessionUrl, { headers: { "facebooktoken": tokens[0] } })
+        .then((sessionResponse) => sessionResponse.data.participants.length);
+    return maxUsers;
 }
 
 async function createSession(token) {
-    var create_session_url = serverUrl + "session";
-    return axios.post(create_session_url, Object(), { headers: { 'facebooktoken': token } })
-        .then((newSession) => {
-            return newSession.data.pin;
-        });
+    var createSessionUrl = serverUrl + "session";
+    return axios.post(createSessionUrl, Object(), { headers: { "facebooktoken": token } })
+        .then((newSession) => newSession.data.pin);
 }
 
 async function getTokens(numTokens) {
@@ -31,7 +27,7 @@ async function getTokens(numTokens) {
         });
     return axios.get(`https://graph.facebook.com/v9.0/822865601801621/accounts/test-users?fields=access_token&limit=${numTokens}&access_token=${appAccessToken}`)
         .then((facebookResponse) => {
-            return facebookResponse.data.data.map(user => user["access_token"]);
+            return facebookResponse.data.data.map((user) => user["access_token"]);
         });
 }
 
@@ -45,7 +41,7 @@ describe.skip("Non-functional Requirements Tests", function () {
 
     it("should have per request latency of < 400ms", async () => {
         const tokens = await getTokens(1);
-        var numRequests = 10;
+        var numRequests = 400;
         var startTime = performance.now();
         for (var i = 0; i < numRequests; i++) {
             await createSession(tokens[0]);

--- a/backend/test/non-functional-requirements/nfr.test.js
+++ b/backend/test/non-functional-requirements/nfr.test.js
@@ -1,0 +1,55 @@
+require("dotenv").config();
+const axios = require("axios");
+const performance = require('perf_hooks').performance;
+
+let serverUrl = "http://52.52.51.125:8081/"
+
+async function testMassJoin(tokens, pin) {
+    var session_url = serverUrl + "session/" + pin;
+    for (var i = 0; i < tokens.length; i++) {
+        await axios.post(session_url, Object(), { headers: { 'facebooktoken': tokens[i] } });
+    }
+    var max_users = await axios.get(session_url, { headers: { 'facebooktoken': tokens[0] } })
+        .then((sessionResponse) => {
+            return sessionResponse.data.participants.length;
+        });
+    return max_users;
+}
+
+async function createSession(token) {
+    var create_session_url = serverUrl + "session";
+    return axios.post(create_session_url, Object(), { headers: { 'facebooktoken': token } })
+        .then((newSession) => {
+            return newSession.data.pin;
+        });
+}
+
+async function getTokens(numTokens) {
+    var appAccessToken = await axios.get(`https://graph.facebook.com/oauth/access_token?client_id=${process.env.FB_APP_ID}&client_secret=${process.env.FB_APP_SECRET}&grant_type=client_credentials`)
+        .then((facebookResponse) => {
+            return facebookResponse.data.access_token;
+        });
+    return axios.get(`https://graph.facebook.com/v9.0/822865601801621/accounts/test-users?fields=access_token&limit=${numTokens}&access_token=${appAccessToken}`)
+        .then((facebookResponse) => {
+            return facebookResponse.data.data.map(user => user["access_token"]);
+        });
+}
+
+describe.skip("Non-functional Requirements Tests", function () {
+    it("should allow 50+ users to join the session", async () => {
+        var numUsers = 55;
+        const tokens = await getTokens(numUsers);
+        const pin = await createSession(tokens[0]);
+        expect(await testMassJoin(tokens.slice(1,), pin)).toBeGreaterThanOrEqual(numUsers);
+    });
+
+    it("should have per request latency of < 400ms", async () => {
+        const tokens = await getTokens(1);
+        var numRequests = 10;
+        var startTime = performance.now();
+        for (var i = 0; i < numRequests; i++) {
+            await createSession(tokens[0]);
+        }
+        expect(performance.now() - startTime).toBeLessThanOrEqual(numRequests * 400);
+    });
+});


### PR DESCRIPTION
Automated non-functional requirement tests, they are currently skipped to reduce server traffic
and to avoid consuming all of our FB API requests.