### PR TITLE
Add error indicator when creating a session with empty list

### DIFF
--- a/frontend/app/src/main/java/com/quickpick/activities/SessionActivity.java
+++ b/frontend/app/src/main/java/com/quickpick/activities/SessionActivity.java
@@ -20,6 +20,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.facebook.AccessToken;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 import com.quickpick.MyFirebaseMessagingService;
 import com.quickpick.R;
 import com.quickpick.payloads.ListPayload;
@@ -49,6 +50,7 @@ public class SessionActivity extends AppCompatActivity {
     private Button startSwipingButton;
 
     private TextInputEditText listEditText;
+    private TextInputLayout listEditTextLayout;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -63,6 +65,7 @@ public class SessionActivity extends AppCompatActivity {
         }
         startSwipingButton = findViewById(R.id.start_swiping_button);
         listEditText = findViewById(R.id.session_list_edit_text);
+        listEditTextLayout = findViewById(R.id.session_list_text_field);
 
         sessionReceiver = new FirebaseIntentReceiver<>(FirebaseIntentReceiver.SESSION_RECEIVER_TAG, SessionPayload.INTENT_KEY);
 
@@ -94,7 +97,13 @@ public class SessionActivity extends AppCompatActivity {
             sessionUserCount.setText(String.format(getString(R.string.session_user_count_format), newSession.getParticipants().size()));
             listEditText.setText(newSession.getListName());
             listEditText.setEnabled(isOwner);
-            startSwipingButton.setEnabled(isOwner);
+            if (newSession.getListName().isEmpty() && isOwner) {
+                listEditTextLayout.setError("Select a list");
+                startSwipingButton.setEnabled(false);
+            } else {
+                listEditTextLayout.setError(null);
+                startSwipingButton.setEnabled(isOwner);
+            }
             sessionKeyView.setText(String.format(getString(R.string.session_code_string_format), newSession.getPin()));
             adapter.updateUsers(newSession.getParticipants());
             adapter.notifyDataSetChanged();
@@ -112,7 +121,7 @@ public class SessionActivity extends AppCompatActivity {
                     new MaterialAlertDialogBuilder(this)
                             .setTitle(getString(R.string.session_list_text))
                             .setNeutralButton(getString(R.string.dialog_cancel_button_text),
-                                    (dialog, which) -> RunnableUtils.showToast(this, getString(R.string.select_list_cancelled)).run())
+                                    (dialog, which) -> {})
                             .setPositiveButton(getString(R.string.dialog_select_button_text),
                                     (dialog, which) -> SessionRepository.getInstance().updateList(RunnableUtils.DO_NOTHING,
                                             RunnableUtils.showToast(this, getString(R.string.select_list_failed)),

--- a/frontend/app/src/main/java/com/quickpick/activities/SummaryActivity.java
+++ b/frontend/app/src/main/java/com/quickpick/activities/SummaryActivity.java
@@ -69,6 +69,7 @@ public class SummaryActivity extends AppCompatActivity {
     }
 
     private void showResults(List<ResultPayload> results) {
+        firstPlaceImage.setScaleType(ImageView.ScaleType.CENTER_CROP);
         if (results.size() > 0) {
             ResultPayload firstPlace = results.get(0);
 
@@ -95,7 +96,6 @@ public class SummaryActivity extends AppCompatActivity {
             }
         } else {
             String noResultsFoundUrl = "https://cdn.dribbble.com/users/1242216/screenshots/9326781/media/6384fef8088782664310666d3b7d4bf2.png";
-            firstPlaceImage.setScaleType(ImageView.ScaleType.CENTER_CROP);
             Glide.with(getApplicationContext()).load(noResultsFoundUrl)
                     .into(firstPlaceImage);
             ((TextView) findViewById(R.id.first_place_idea_text)).setText(R.string.no_results_found_text);

--- a/frontend/app/src/main/res/layout/activity_session.xml
+++ b/frontend/app/src/main/res/layout/activity_session.xml
@@ -39,6 +39,7 @@
         android:layout_width="288dp"
         android:layout_height="wrap_content"
         android:hint="@string/selected_list_text"
+        app:errorEnabled="true"
         app:layout_constraintBottom_toTopOf="@+id/start_swiping_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"

--- a/frontend/app/src/main/res/values/strings.xml
+++ b/frontend/app/src/main/res/values/strings.xml
@@ -29,7 +29,6 @@
     <string name="quick_text">quick</string>
     <string name="pick_text">Pick</string>
     <string name="selected_list_text">Selected List</string>
-    <string name="select_list_cancelled">Did not select new list</string>
     <string name="select_list_failed">List update failed, try again</string>
     <string name="get_list_failed">Failed to get list for swiping</string>
     <string name="get_lists_failed">Failed to get lists</string>


### PR DESCRIPTION
The error indicator informs the user that they must start a session
and disabling the start session button prevents them from starting a session
prior to selecting a list.
Also fixed an issue where the image scaling was incorrect for the summary.